### PR TITLE
refactor: Migrate to new file actions for 28

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -29,9 +29,9 @@ jobs:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        php-versions: ['8.0', '8.1']
+        php-versions: ['8.3']
         databases: ['sqlite']
-        server-versions: ['master', 'stable27', 'stable26']
+        server-versions: ['master']
 
     name: php${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,7 +17,7 @@
 	<screenshot>https://raw.githubusercontent.com/nextcloud/integration_slack/main/img/screenshot1.png</screenshot>
 	<screenshot>https://raw.githubusercontent.com/nextcloud/integration_slack/main/img/screenshot2.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="26" max-version="28"/>
+		<nextcloud min-version="28" max-version="28"/>
 	</dependencies>
 	<settings>
 		<admin>OCA\Slack\Settings\Admin</admin>

--- a/css/integration_slack-files.css
+++ b/css/integration_slack-files.css
@@ -1,8 +1,0 @@
-/* for file actions */
-.icon-slack {
-	background-image: url('../img/app-dark.svg');
-	filter: var(--background-invert-if-dark);
-}
-body.theme--dark .icon-slack {
-	background-image: url('../img/app.svg');
-}

--- a/lib/Listener/FilesMenuListener.php
+++ b/lib/Listener/FilesMenuListener.php
@@ -37,7 +37,6 @@ class FilesMenuListener implements IEventListener {
       return;
     }
 
-    Util::addScript(Application::APP_ID, Application::APP_ID . '-filesplugin', 'files');
-    Util::addStyle(Application::APP_ID, Application::APP_ID . '-files');
+    Util::addInitScript(Application::APP_ID, Application::APP_ID . '-filesplugin');
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,19 @@
 {
 	"name": "integration_slack",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "integration_slack",
-			"version": "1.0.0",
+			"version": "1.0.1",
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"@nextcloud/auth": "^2.0.0",
 				"@nextcloud/axios": "^2.0.0",
 				"@nextcloud/dialogs": "^4.0.1",
+				"@nextcloud/event-bus": "^3.1.0",
+				"@nextcloud/files": "^3.0.0",
 				"@nextcloud/initial-state": "^2.0.0",
 				"@nextcloud/l10n": "^2.0.1",
 				"@nextcloud/moment": "^1.1.1",
@@ -30,8 +32,8 @@
 				"stylelint-webpack-plugin": "^4.0.0"
 			},
 			"engines": {
-				"node": "^16.0.0",
-				"npm": "^7.0.0 || ^8.0.0"
+				"node": "^20.0.0",
+				"npm": "^9.6.4"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -1757,6 +1759,14 @@
 			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
 		},
+		"node_modules/@buttercup/fetch": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@buttercup/fetch/-/fetch-0.1.2.tgz",
+			"integrity": "sha512-mDBtsysQ0Gnrp4FamlRJGpu7HUHwbyLC4uUav1I7QAqThFAa/4d1cdZCxrV5gKvh6zO1fu95bILNJi4Y2hALhQ==",
+			"optionalDependencies": {
+				"node-fetch": "^3.3.0"
+			}
+		},
 		"node_modules/@csstools/selector-specificity": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
@@ -2740,15 +2750,15 @@
 			}
 		},
 		"node_modules/@nextcloud/auth": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.1.0.tgz",
-			"integrity": "sha512-wf5xQrWQu6fkl3MGegVdyR5mh/EdSQKJByH3m2Url2K2xbML9Y4Y7LAff9jjJAcMt2MkzzJEM463ZBbgTqs0lg==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.2.1.tgz",
+			"integrity": "sha512-zYtgrg9NMZfN8kmL5JPCsh5jDhpTCEslhnZWMvbhTiQ7hrOnji/67ok6VMK0CTJ1a92Vr67Ow72lW7YRX69zEA==",
 			"dependencies": {
 				"@nextcloud/event-bus": "^3.1.0"
 			},
 			"engines": {
-				"node": "^16.0.0",
-				"npm": "^7.0.0 || ^8.0.0"
+				"node": "^20.0.0",
+				"npm": "^9.0.0"
 			}
 		},
 		"node_modules/@nextcloud/axios": {
@@ -2915,6 +2925,38 @@
 				"npm": "^7.0.0 || ^8.0.0"
 			}
 		},
+		"node_modules/@nextcloud/files": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.0.0.tgz",
+			"integrity": "sha512-zk5oIuVDyk2gWBKCJ+0B1HE3VjhuGnz2iLNbTcbRuTjMYb6aYCAEn1LY0dXbUQG93ehndYJCOdaYri/TaGrlXw==",
+			"dependencies": {
+				"@nextcloud/auth": "^2.2.1",
+				"@nextcloud/l10n": "^2.2.0",
+				"@nextcloud/logger": "^2.7.0",
+				"@nextcloud/paths": "^2.1.0",
+				"@nextcloud/router": "^2.2.0",
+				"is-svg": "^5.0.0",
+				"webdav": "^5.3.0"
+			},
+			"engines": {
+				"node": "^20.0.0",
+				"npm": "^9.0.0"
+			}
+		},
+		"node_modules/@nextcloud/files/node_modules/is-svg": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-svg/-/is-svg-5.0.0.tgz",
+			"integrity": "sha512-sRl7J0oX9yUNamSdc8cwgzh9KBLnQXNzGmW0RVHwg/jEYjGNYHC6UvnYD8+hAeut9WwxRvhG9biK7g/wDGxcMw==",
+			"dependencies": {
+				"fast-xml-parser": "^4.1.3"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/@nextcloud/initial-state": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-2.0.0.tgz",
@@ -2937,16 +2979,16 @@
 			}
 		},
 		"node_modules/@nextcloud/logger": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/logger/-/logger-2.5.0.tgz",
-			"integrity": "sha512-vJx5YxPyS9/tg3YoqA8CBN7YTZFHfuhMKJIIWFV28phxXqKhGwKVKh+/Ir8ZIPweIM5n8VNT6JOJq1JjGiMg2w==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/logger/-/logger-2.7.0.tgz",
+			"integrity": "sha512-DSJg9H1jT2zfr7uoP4tL5hKncyY+LOuxJzLauj0M/f6gnpoXU5WG1Zw8EFPOrRWjkC0ZE+NCqrMnITgdRRpXJQ==",
 			"dependencies": {
 				"@nextcloud/auth": "^2.0.0",
 				"core-js": "^3.6.4"
 			},
 			"engines": {
-				"node": "^16.0.0",
-				"npm": "^7.0.0 || ^8.0.0"
+				"node": "^20.0.0",
+				"npm": "^9.0.0"
 			}
 		},
 		"node_modules/@nextcloud/moment": {
@@ -2970,17 +3012,25 @@
 				"node-gettext": "^3.0.0"
 			}
 		},
-		"node_modules/@nextcloud/router": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.1.2.tgz",
-			"integrity": "sha512-Jj5fgjeHT1vVIgOyUGOeHfwk2KgaO77QGfqZAT6GWXvpAsN0mkqwljkg4FkHrQRouYqCE4VnJ5o8/w0DAN89tA==",
+		"node_modules/@nextcloud/paths": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/paths/-/paths-2.1.0.tgz",
+			"integrity": "sha512-8wX0gqwez0bTuAS8A0OEiqbbp0ZsqLr07zSErmS6OYhh9KZcSt/kO6lQV5tnrFqIqJVsxwz4kHUjtZXh6DSf9Q==",
 			"dependencies": {
-				"@nextcloud/typings": "^1.0.0",
+				"core-js": "^3.6.4"
+			}
+		},
+		"node_modules/@nextcloud/router": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.2.0.tgz",
+			"integrity": "sha512-M4AVGnB5tt3MYO5RpH/R2jq7z/nW05AmRhk4Lh68krVwRIYGo8pgNikKrPGogHd2Q3UgzF5Py1drHz3uuV99bQ==",
+			"dependencies": {
+				"@nextcloud/typings": "^1.7.0",
 				"core-js": "^3.6.4"
 			},
 			"engines": {
-				"node": "^16.0.0",
-				"npm": "^7.0.0 || ^8.0.0"
+				"node": "^20.0.0",
+				"npm": "^9.0.0"
 			}
 		},
 		"node_modules/@nextcloud/stylelint-config": {
@@ -4999,6 +5049,11 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
 		},
+		"node_modules/base-64": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+			"integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
+		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -5335,6 +5390,11 @@
 			"dependencies": {
 				"semver": "^7.0.0"
 			}
+		},
+		"node_modules/byte-length": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/byte-length/-/byte-length-1.0.2.tgz",
+			"integrity": "sha512-ovBpjmsgd/teRmgcPh23d4gJvxDoXtAzEL9xTfMU8Yc2kqCDb7L9jAG0XHl1nzuGl+h3ebCIF1i62UFyA9V/2Q=="
 		},
 		"node_modules/bytes": {
 			"version": "3.0.0",
@@ -5974,6 +6034,15 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
 			"integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+		},
+		"node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"optional": true,
+			"engines": {
+				"node": ">= 12"
+			}
 		},
 		"node_modules/date-format-parse": {
 			"version": "0.2.7",
@@ -7613,6 +7682,29 @@
 				"bser": "2.1.1"
 			}
 		},
+		"node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"optional": true,
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -7802,6 +7894,18 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"optional": true,
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
 			}
 		},
 		"node_modules/forwarded": {
@@ -8312,8 +8416,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
 			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-			"dev": true,
-			"peer": true,
 			"bin": {
 				"he": "bin/he"
 			}
@@ -8360,6 +8462,11 @@
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true,
 			"peer": true
+		},
+		"node_modules/hot-patcher": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/hot-patcher/-/hot-patcher-2.0.1.tgz",
+			"integrity": "sha512-ECg1JFG0YzehicQaogenlcs2qg6WsXQsxtnbr1i696u5tLUjtJdQAh0u2g0Q5YV45f263Ta1GnUJsc8WIfJf4Q=="
 		},
 		"node_modules/hpack.js": {
 			"version": "2.1.6",
@@ -10927,6 +11034,11 @@
 				"shell-quote": "^1.7.3"
 			}
 		},
+		"node_modules/layerr": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/layerr/-/layerr-2.0.1.tgz",
+			"integrity": "sha512-z0730CwG/JO24evdORnyDkwG1Q7b7mF2Tp1qRQ0YvrMMARbt1DFG694SOv439Gm7hYKolyZyaB49YIrYIfZBdg=="
+		},
 		"node_modules/leven": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -12009,6 +12121,48 @@
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
 			"peer": true
 		},
+		"node_modules/nested-property": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/nested-property/-/nested-property-4.0.0.tgz",
+			"integrity": "sha512-yFehXNWRs4cM0+dz7QxCd06hTbWbSkV0ISsqBfkntU6TOY4Qm3Q88fRRLOddkGh2Qq6dZvnKVAahfhjcUvLnyA=="
+		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"optional": true,
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"optional": true,
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
+			}
+		},
 		"node_modules/node-forge": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -12446,6 +12600,11 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
 			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+		},
+		"node_modules/path-posix": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz",
+			"integrity": "sha512-1gJ0WpNIiYcQydgg3Ed8KzvIqTsDpNwq+cjBCssvBtuTWjEqY1AW+i+OepiEMqDCzyro9B2sLAe4RBPajMYFiA=="
 		},
 		"node_modules/path-to-regexp": {
 			"version": "0.1.7",
@@ -12988,6 +13147,11 @@
 				"node": ">=0.4.x"
 			}
 		},
+		"node_modules/querystringify": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -13420,9 +13584,7 @@
 		"node_modules/requires-port": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-			"dev": true,
-			"peer": true
+			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
 		},
 		"node_modules/resolve": {
 			"version": "1.22.2",
@@ -15477,6 +15639,23 @@
 				"qs": "^6.11.0"
 			}
 		},
+		"node_modules/url-join": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
+			"integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			}
+		},
+		"node_modules/url-parse": {
+			"version": "1.5.10",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+			"integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+			"dependencies": {
+				"querystringify": "^2.1.1",
+				"requires-port": "^1.0.0"
+			}
+		},
 		"node_modules/url/node_modules/punycode": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -15885,6 +16064,60 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/web-streams-polyfill": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+			"integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+			"optional": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/webdav": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/webdav/-/webdav-5.3.0.tgz",
+			"integrity": "sha512-xRu/URZGCxDPXmT+9Gu6tNGvlETBwjcuz69lx/6Qlq/0q3Gu2GSVyRt+mP0vTlLFfaY3xZ5O/SPTQ578tC/45Q==",
+			"dependencies": {
+				"@buttercup/fetch": "^0.1.1",
+				"base-64": "^1.0.0",
+				"byte-length": "^1.0.2",
+				"fast-xml-parser": "^4.2.4",
+				"he": "^1.2.0",
+				"hot-patcher": "^2.0.0",
+				"layerr": "^2.0.1",
+				"md5": "^2.3.0",
+				"minimatch": "^7.4.6",
+				"nested-property": "^4.0.0",
+				"path-posix": "^1.0.0",
+				"url-join": "^5.0.0",
+				"url-parse": "^1.5.10"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/webdav/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/webdav/node_modules/minimatch": {
+			"version": "7.4.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
+			"integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/webpack": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
 		"@nextcloud/auth": "^2.0.0",
 		"@nextcloud/axios": "^2.0.0",
 		"@nextcloud/dialogs": "^4.0.1",
+		"@nextcloud/event-bus": "^3.1.0",
+		"@nextcloud/files": "^3.0.0",
 		"@nextcloud/initial-state": "^2.0.0",
 		"@nextcloud/l10n": "^2.0.1",
 		"@nextcloud/moment": "^1.1.1",

--- a/src/components/SendFilesModal.vue
+++ b/src/components/SendFilesModal.vue
@@ -237,6 +237,7 @@ import { generateUrl } from '@nextcloud/router'
 import { showError } from '@nextcloud/dialogs'
 import SlackIcon from './icons/SlackIcon.vue'
 import { humanFileSize, SEND_TYPE } from '../utils.js'
+import { FileType } from '@nextcloud/files'
 
 const STATES = {
 	IN_PROGRESS: 1,
@@ -383,7 +384,7 @@ export default {
 			})
 		},
 		getFilePreviewUrl(fileId, fileType) {
-			if (fileType === 'dir') {
+			if (fileType === FileType.Folder) {
 				return generateUrl('/apps/theming/img/core/filetypes/folder.svg')
 			}
 			return generateUrl('/apps/integration_slack/preview?id={fileId}&x=24&y=24', { fileId })

--- a/webpack.js
+++ b/webpack.js
@@ -33,5 +33,9 @@ webpackConfig.plugins.push(
 		failOnError: !isDev,
 	}),
 )
+webpackConfig.module.rules.push({
+	test: /\.svg$/i,
+	type: 'asset/source',
+})
 
 module.exports = webpackConfig


### PR DESCRIPTION
The way I did it might not be the cleanest but I found it to be the least amount of work:
1. Copy the filesplugin.js from integration_mattermost
2. Apply all the changes from https://github.com/nextcloud/integration_mattermost/compare/main...nextcloud:integration_slack:main (only filesplugin.js) that are Slack specific.
3. Adjust the min version and dependencies